### PR TITLE
Fix author history with .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Javier Cuesta <jav.cuesta@gmail.com> <jav.cuesta@gmail.com>

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,7 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [VaultCourier]
+    - documentation_targets:
+      - VaultCourier
+metadata:
+  authors: "Javier Cuesta"

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import PackageDescription
 
 let package = Package(
     name: "vault-courier",
-    platforms: [.macOS(.v15)],
+    platforms: [.macOS(.v15), .iOS(.v18), .visionOS(.v2), .tvOS(.v18), .watchOS(.v11)],
     products: [
         .library(name: "VaultCourier", targets: ["VaultCourier"]),
     ],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 
 ## VaultCourier
 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fvault-courier%2Fvault-courier%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/vault-courier/vault-courier)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fvault-courier%2Fvault-courier%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/vault-courier/vault-courier)
+
 Swift client for interacting with Hashicorp Vault and OpenBao.
 
 [Hashicorp Vault](https://developer.hashicorp.com/vault) and [OpenBao](https://openbao.org) are both tools for securely storing, auditing and managing access to secrets, such as API tokens, database credentials, and certificates. VaultCourier is a [swift](https://www.swift.org) package that can interact with Hashicorp Vault and OpenBao to retrieve and provision secrets. It is built with [swift-openapi](https://github.com/apple/swift-openapi-generator) and [pkl](https://pkl-lang.org).


### PR DESCRIPTION
Fix committers author history with mailmap file. Usually gitmailmap is used to fix authors with different emails. However this also works when the git username is different, but the email is the same which was my case. In any case, I added the authors metadata in spi manifest.