### PR TITLE
Remove unsupported platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import PackageDescription
 
 let package = Package(
     name: "vault-courier",
-    platforms: [.macOS(.v15), .iOS(.v18), .visionOS(.v2), .tvOS(.v18), .watchOS(.v11)],
+    platforms: [.macOS(.v15)],
     products: [
         .library(name: "VaultCourier", targets: ["VaultCourier"]),
     ],


### PR DESCRIPTION
pkl-swift only supports macOS at the moment. However, it seems the team [want](https://github.com/apple/pkl-swift/issues/15#issuecomment-1963890247) to extend the support to iOS as well. Removing this until then