### PR TITLE
Bump Pkl to 0.6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -87,7 +87,7 @@ let package = Package(
             DatabaseEngineTrait.name,
             PostgresDatabasePluginTrait.name,
             ValkeyDatabasePluginTrait.name,
-//            PklTrait.name,
+//            PklTrait.name
         ])
     ],
     dependencies: [
@@ -95,7 +95,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-runtime.git", from: "1.7.0"),
         .package(url: "https://github.com/swift-server/swift-openapi-async-http-client.git", from: "1.1.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.0"),
-        .package(url: "https://github.com/apple/pkl-swift", from: "0.4.2"),
+        .package(url: "https://github.com/apple/pkl-swift", .upToNextMinor(from: "0.6.0")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4")
     ],
     targets: [

--- a/Tests/VaultCourierTests/Gen/AppRoleToken.pkl.swift
+++ b/Tests/VaultCourierTests/Gen/AppRoleToken.pkl.swift
@@ -7,7 +7,7 @@ public enum AppRoleToken {}
 extension AppRoleToken {
     /// This is the DTO for generating a new Secret-ID for an AppRole
     /// See AppRoleAuth.pkl and [API](https://developer.hashicorp.com/vault/api-docs/auth/approle#parameters-5)
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "AppRoleToken"
 
         /// Name of the AppRole. Must be less than 4096 bytes.

--- a/Tests/VaultCourierTests/Gen/AuthMethodConfig.pkl.swift
+++ b/Tests/VaultCourierTests/Gen/AuthMethodConfig.pkl.swift
@@ -5,12 +5,12 @@ import PklSwift
 public enum AuthMethodConfig {}
 
 extension AuthMethodConfig {
-    public enum AuthMethod: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum AuthMethod: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case approle = "approle"
         case token = "token"
     }
 
-    public enum ConfigKey: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum ConfigKey: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case default_lease_ttl = "default_lease_ttl"
         case max_lease_ttl = "max_lease_ttl"
         case force_no_cache = "force_no_cache"
@@ -24,7 +24,7 @@ extension AuthMethodConfig {
     }
 
     /// Payload for enabling auth methods
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "AuthMethodConfig"
 
         /// Specifies the path in which to enable the auth method. This is part of the request URL.

--- a/Tests/VaultCourierTests/Gen/MountConfiguration.pkl.swift
+++ b/Tests/VaultCourierTests/Gen/MountConfiguration.pkl.swift
@@ -5,12 +5,12 @@ import PklSwift
 public enum MountConfiguration {}
 
 extension MountConfiguration {
-    public enum SecretEngine: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum SecretEngine: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case kv = "kv"
         case database = "database"
     }
 
-    public enum ConfigKey: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum ConfigKey: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case default_lease_ttl = "default_lease_ttl"
         case max_lease_ttl = "max_lease_ttl"
         case force_no_cache = "force_no_cache"
@@ -24,7 +24,7 @@ extension MountConfiguration {
     }
 
     /// Vault System Mount. Enables a new secrets engine at the given path
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "MountConfiguration"
 
         /// Specifies the type of the backend, such as "kv", "database", "aws", etc...

--- a/Tests/VaultCourierTests/Gen/PostgresDatabaseConnection.pkl.swift
+++ b/Tests/VaultCourierTests/Gen/PostgresDatabaseConnection.pkl.swift
@@ -1,4 +1,3 @@
-
 #if PklSupport
 // Code generated from Pkl module `PostgresDatabaseConnection`. DO NOT EDIT.
 import PklSwift
@@ -6,7 +5,7 @@ import PklSwift
 public enum PostgresDatabaseConnection {}
 
 extension PostgresDatabaseConnection {
-    public enum PostgresSSLMode: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum PostgresSSLMode: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case disable = "disable"
         case allow = "allow"
         case prefer = "prefer"
@@ -17,7 +16,7 @@ extension PostgresDatabaseConnection {
 
     /// This is the payload for configuring Vault and Postgres connections
     /// https://developer.hashicorp.com/vault/api-docs/secret/databases/postgresql
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresDatabaseConnection"
 
         /// Custom database engine path

--- a/Tests/VaultCourierTests/Gen/PostgresRole.pkl.swift
+++ b/Tests/VaultCourierTests/Gen/PostgresRole.pkl.swift
@@ -5,7 +5,7 @@ import PklSwift
 public enum PostgresRole {}
 
 extension PostgresRole {
-    public enum CredentialType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum CredentialType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case password = "password"
         case rsa_private_key = "rsa_private_key"
         case client_certificate = "client_certificate"
@@ -14,7 +14,7 @@ extension PostgresRole {
     /// Dynamic Postgres Database Role
     ///
     /// [Vault documentation](https://developer.hashicorp.com/vault/api-docs/secret/databases#create-role)
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresRole"
 
         /// Specifies the name of the role to create. This is specified as part of the URL.
@@ -85,7 +85,7 @@ extension PostgresRole {
         }
     }
 
-    public struct PasswordCredential: PklRegisteredType, Decodable, Hashable {
+    public struct PasswordCredential: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresRole#PasswordCredential"
 
         public var passwordPolicy: String?
@@ -95,7 +95,7 @@ extension PostgresRole {
         }
     }
 
-    public struct RSAPrivateKey: PklRegisteredType, Decodable, Hashable {
+    public struct RSAPrivateKey: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresRole#RSAPrivateKey"
 
         public var key_bits: Int?
@@ -108,7 +108,7 @@ extension PostgresRole {
         }
     }
 
-    public struct ClientCertificate: PklRegisteredType, Decodable, Hashable {
+    public struct ClientCertificate: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresRole#ClientCertificate"
 
         /// A username template to be used for the client certificate common name.

--- a/Tests/VaultCourierTests/Gen/PostgresStaticRole.pkl.swift
+++ b/Tests/VaultCourierTests/Gen/PostgresStaticRole.pkl.swift
@@ -5,7 +5,7 @@ import PklSwift
 public enum PostgresStaticRole {}
 
 extension PostgresStaticRole {
-    public enum CredentialType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum CredentialType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case password = "password"
         case rsa_private_key = "rsa_private_key"
         case client_certificate = "client_certificate"
@@ -14,7 +14,7 @@ extension PostgresStaticRole {
     /// Postgres Static Role
     ///
     /// [Vault Static Role documentation](https://developer.hashicorp.com/vault/api-docs/secret/databases#create-static-role)
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresStaticRole"
 
         /// The corresponding role in the database of `db_username`
@@ -78,17 +78,7 @@ extension PostgresStaticRole {
         }
     }
 
-    public struct RotationPeriod: PklRegisteredType, Decodable, Hashable {
-        public static let registeredIdentifier: String = "PostgresStaticRole#RotationPeriod"
-
-        public var period: Duration
-
-        public init(period: Duration) {
-            self.period = period
-        }
-    }
-
-    public struct RotationSchedule: PklRegisteredType, Decodable, Hashable {
+    public struct RotationSchedule: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresStaticRole#RotationSchedule"
 
         public var schedule: String
@@ -101,7 +91,18 @@ extension PostgresStaticRole {
         }
     }
 
-    public struct PasswordCredential: PklRegisteredType, Decodable, Hashable {
+    /// Specifies the amount of time Vault should wait before rotating the password. The minimum is 5 seconds.
+    public struct RotationPeriod: PklRegisteredType, Decodable, Hashable, Sendable {
+        public static let registeredIdentifier: String = "PostgresStaticRole#RotationPeriod"
+
+        public var period: Duration
+
+        public init(period: Duration) {
+            self.period = period
+        }
+    }
+
+    public struct PasswordCredential: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresStaticRole#PasswordCredential"
 
         public var passwordPolicy: String?
@@ -111,7 +112,7 @@ extension PostgresStaticRole {
         }
     }
 
-    public struct RSAPrivateKey: PklRegisteredType, Decodable, Hashable {
+    public struct RSAPrivateKey: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresStaticRole#RSAPrivateKey"
 
         public var key_bits: Int?
@@ -124,7 +125,7 @@ extension PostgresStaticRole {
         }
     }
 
-    public struct ClientCertificate: PklRegisteredType, Decodable, Hashable {
+    public struct ClientCertificate: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "PostgresStaticRole#ClientCertificate"
 
         /// A username template to be used for the client certificate common name.

--- a/Tests/VaultCourierTests/Gen/VaultAppRole.pkl.swift
+++ b/Tests/VaultCourierTests/Gen/VaultAppRole.pkl.swift
@@ -5,7 +5,7 @@ import PklSwift
 public enum VaultAppRole {}
 
 extension VaultAppRole {
-    public enum TokenType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum TokenType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case batch = "batch"
         case service = "service"
         case `default` = "default"
@@ -13,7 +13,7 @@ extension VaultAppRole {
 
     /// Configuration for creating a Vault AppRole
     /// https://developer.hashicorp.com/vault/api-docs/auth/approle#create-update-approle
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "VaultAppRole"
 
         /// Custom approle auth path. This value was given in AuthMethodConfig

--- a/Tests/VaultCourierTests/Gen/VaultPolicy.pkl.swift
+++ b/Tests/VaultCourierTests/Gen/VaultPolicy.pkl.swift
@@ -5,7 +5,7 @@ import PklSwift
 public enum VaultPolicy {}
 
 extension VaultPolicy {
-    public enum Capability: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum Capability: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case create = "create"
         case read = "read"
         case update = "update"
@@ -14,7 +14,7 @@ extension VaultPolicy {
         case sudo = "sudo"
     }
 
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "VaultPolicy"
 
         /// Policy name
@@ -28,7 +28,7 @@ extension VaultPolicy {
         }
     }
 
-    public struct PathPolicy: PklRegisteredType, Decodable, Hashable {
+    public struct PathPolicy: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "VaultPolicy#PathPolicy"
 
         public var capabilities: [Capability]

--- a/Tests/VaultCourierTests/Gen/VaultToken.pkl.swift
+++ b/Tests/VaultCourierTests/Gen/VaultToken.pkl.swift
@@ -5,7 +5,7 @@ import PklSwift
 public enum VaultToken {}
 
 extension VaultToken {
-    public enum TokenType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum TokenType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case batch = "batch"
         case service = "service"
     }
@@ -13,7 +13,7 @@ extension VaultToken {
     /// DTO for creating a Token.
     ///
     /// See <https://developer.hashicorp.com/vault/api-docs/auth/token#create-token>
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "VaultToken"
 
         /// The ID of the client token. Can only be specified by a root token. The ID provided may not contain a . character. Otherwise, the token ID is a randomly generated value.

--- a/Tests/VaultCourierTests/Pkl+ModuleSourceReader.swift
+++ b/Tests/VaultCourierTests/Pkl+ModuleSourceReader.swift
@@ -330,7 +330,7 @@ extension IntegrationTests.Pkl {
             }
         }
 
-#if PostgresPluginSupport
+        #if PostgresPluginSupport
         @Test
         func read_credentials_for_two_database_secret_mounts() async throws {
             struct DatabaseSecrets: Codable, Sendable {

--- a/Tests/VaultCourierTests/Pkl+VaultCourierPayloads.swift
+++ b/Tests/VaultCourierTests/Pkl+VaultCourierPayloads.swift
@@ -28,7 +28,6 @@ import VaultCourier
 
 extension IntegrationTests.Pkl {
     @Suite(
-        .disabled(), // Bug: This suite can only be called individually. Otherwise, it blocks when run with other suits. Seems to be due to Pkl
         .setupPkl(execPath: env("PKL_EXEC") ?? "/opt/homebrew/bin/pkl")
     )
     struct Payloads {


### PR DESCRIPTION
Bump Pkl dependency to 0.6.0 which supports Swift 6. This closes #56 

- This solves some concurrency issues (blocking) observed when loading Pkl modules simultaneously on tests