### PR TITLE
Add default PackageTraits explicitly

### DIFF
--- a/Sources/VaultCourier/Documentation.docc/Tutorials/Resources/code-files/approle-hummingbird/hummingbird.pkl.0.0.0.swift
+++ b/Sources/VaultCourier/Documentation.docc/Tutorials/Resources/code-files/approle-hummingbird/hummingbird.pkl.0.0.0.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.21.0"),
-        .package(url: "https://github.com/vault-courier/vault-courier", .upToNextMinor(from: "0.3.0"), traits: ["PklSupport"]),
+        .package(url: "https://github.com/vault-courier/vault-courier", .upToNextMinor(from: "0.3.0"), traits: [.defaults, "PklSupport"]),
         .package(url: "https://github.com/swift-server/swift-openapi-async-http-client.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/pkl-swift", .upToNextMinor(from: "0.6.0"))
     ],

--- a/Sources/VaultCourier/Documentation.docc/Tutorials/Resources/code-files/approle-hummingbird/hummingbird.pkl.0.0.1.swift
+++ b/Sources/VaultCourier/Documentation.docc/Tutorials/Resources/code-files/approle-hummingbird/hummingbird.pkl.0.0.1.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.21.0"),
-        .package(url: "https://github.com/vault-courier/vault-courier", .upToNextMinor(from: "0.3.0"), traits: ["PklSupport"]),
+        .package(url: "https://github.com/vault-courier/vault-courier", .upToNextMinor(from: "0.3.0"), traits: [.defaults, "PklSupport"]),
         .package(url: "https://github.com/swift-server/swift-openapi-async-http-client.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/pkl-swift", .upToNextMinor(from: "0.6.0"))
     ],

--- a/Sources/VaultCourier/Documentation.docc/Tutorials/Resources/code-files/approle-vapor/vapor.pkl.0.0.0.swift
+++ b/Sources/VaultCourier/Documentation.docc/Tutorials/Resources/code-files/approle-vapor/vapor.pkl.0.0.0.swift
@@ -19,7 +19,7 @@ let package = Package(
         // 🔵 Non-blocking, event-driven networking for Swift. Used for custom executors
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
         // 🔐 Client for interacting with Hashicorp Vault and OpenBao
-        .package(url: "https://github.com/vault-courier/vault-courier", .upToNextMinor(from: "0.3.0"), traits: ["PklSupport"]),
+        .package(url: "https://github.com/vault-courier/vault-courier", .upToNextMinor(from: "0.3.0"), traits: [.defaults, "PklSupport"]),
         // 🚀 Transport type for VaultCourier
         .package(url: "https://github.com/swift-server/swift-openapi-async-http-client.git", from: "1.1.0"),
         // Straightforward, type-safe argument parsing

--- a/Sources/VaultCourier/Documentation.docc/Tutorials/Resources/code-files/approle-vapor/vapor.pkl.0.0.1.swift
+++ b/Sources/VaultCourier/Documentation.docc/Tutorials/Resources/code-files/approle-vapor/vapor.pkl.0.0.1.swift
@@ -19,7 +19,7 @@ let package = Package(
         // 🔵 Non-blocking, event-driven networking for Swift. Used for custom executors
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
         // 🔐 Client for interacting with Hashicorp Vault and OpenBao
-        .package(url: "https://github.com/vault-courier/vault-courier", .upToNextMinor(from: "0.3.0"), traits: ["PklSupport"]),
+        .package(url: "https://github.com/vault-courier/vault-courier", .upToNextMinor(from: "0.3.0"), traits: [.defaults, "PklSupport"]),
         // 🚀 Transport type for VaultCourier
         .package(url: "https://github.com/swift-server/swift-openapi-async-http-client.git", from: "1.1.0"),
         // Straightforward, type-safe argument parsing


### PR DESCRIPTION
Updates tutorials with default PackageTraits explicitly added. Required with Swift 6.2.3