### PR TITLE
Insert explicit swift-configuration package trait

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -122,7 +122,7 @@ let package = Package(
         .package(url: "https://github.com/apple/pkl-swift", .upToNextMinor(from: "0.8.2")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.3.1"),
-        .package(url: "https://github.com/apple/swift-configuration.git", .upToNextMinor(from: "0.1.1")),
+        .package(url: "https://github.com/apple/swift-configuration.git", .upToNextMinor(from: "0.1.1"), traits: ["JSONSupport"]),
     ],
     targets: [
         .target(


### PR DESCRIPTION
The JSONSupport trait was renamed in the released version to JSON. Documentation was not building as the default was mapping to a trait that does not exist